### PR TITLE
Add continuous integration engines

### DIFF
--- a/libs/ci.json
+++ b/libs/ci.json
@@ -1,5 +1,5 @@
 [
   {"id": "ci.circleci", "imports": [".circleci/config.yml"], "name": "CircleCI", "repo": "CircleCI-Public/circleci-demo-go", "tags": ["ci","continuous-integration","circleci"], "tech": ["continuous-integration"], "status": "awaiting-model"},
-  {"id": "ci.travis", "imports": [".travis.yml"], "name": "Travis CI", "repo": "dmlc/xgboost", "tags": ["ci","continuous-integration","travis"], "tech": ["continuous-integration"], "status": "awaiting-model"},
-  {"id": "ci.gh-actons", "imports": [".github/main.workflow"], "name": "GitHub Actions", "repo": "pocoproject/poco", "tags": ["ci","continuous-integration"], "tech": ["continuous-integration"], "status": "awaiting-model"}
+  {"id": "ci.travis", "imports": [".travis.yml"], "name": "Travis CI", "tags": ["ci","continuous-integration","travis"], "tech": ["continuous-integration"], "status": "awaiting-model"},
+  {"id": "ci.gh-actons", "imports": [".github/main.workflow"], "name": "GitHub Actions", "tags": ["ci","continuous-integration"], "tech": ["continuous-integration"], "status": "awaiting-model"}
 ]

--- a/libs/ci.json
+++ b/libs/ci.json
@@ -1,0 +1,5 @@
+[
+  {"id": "ci.circleci", "imports": [".circleci/config.yml"], "name": "CircleCI", "repo": "CircleCI-Public/circleci-demo-go", "tags": ["ci","continuous-integration","circleci"], "tech": ["continuous-integration"], "status": "awaiting-model"},
+  {"id": "ci.travis", "imports": [".travis.yml"], "name": "Travis CI", "repo": "dmlc/xgboost", "tags": ["ci","continuous-integration","travis"], "tech": ["continuous-integration"], "status": "awaiting-model"},
+  {"id": "ci.gh-actons", "imports": [".github/main.workflow"], "name": "GitHub Actions", "repo": "pocoproject/poco", "tags": ["ci","continuous-integration"], "tech": ["continuous-integration"], "status": "awaiting-model"}
+]

--- a/technologies.json
+++ b/technologies.json
@@ -306,6 +306,7 @@
       "multiprecision",
       "ndim-cubes",
       "numbers",
+      "operations-research",
       "optimization",
       "random",
       "real-time-dsp",
@@ -335,6 +336,14 @@
       "java-json",
       "properties",
       "ucl"
+    ]
+  },
+  "continuous-integration": {
+    "tags": [
+      "ci",
+      "circleci",
+      "continuous-integration",
+      "travis"
     ]
   },
   "cpp-web": {


### PR DESCRIPTION
I reviewed contributing doc, and I dont know if this type of file based inspection is supported.

I thought it would be cool to scan for known CI configuration files, and this just stubs a few to see if there is interest/support for such a feature.

- .circleci/config.yml
- .travis.yaml
- .github/main.workflow


I don't know why running `node technologies.js` added the `operations-research` tag