### PR TITLE
fix: lib coverage fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Hi there! We welcome contributions to Libraries to improve Sourcerer and help it
 
 ## Adding a library
 
-We try only to add libraries once they have some usage. We prefer libraries to be in use in hundreds of repositories before supporting them in Sourcerer. You can also refer to [coverage chart](tools/coverage/index.html) to see what languages need more support.
+We try only to add libraries once they have some usage. We prefer libraries to be in use in hundreds of repositories before supporting them in Sourcerer. You can also refer to [coverage chart](https://raw.githack.com/sourcerer-io/awesome-libraries/master/tools/coverage/index.html) to see what languages need more support.
 
 To add support for a new library:
 

--- a/tools/coverage/index.js
+++ b/tools/coverage/index.js
@@ -36,7 +36,6 @@ window.onload = () => {
     x: labels,
     y: values,
     type: 'bar',
-    name: 'Langs ordered by popularity',
   }];
   let layout = {
     title: 'Sourcerer libraries coverage<br>Languages are ordered by popularity',


### PR DESCRIPTION
lib coverage link is not working in contributing docs;
remove unused 'name' arg from plot chart in lib coverage