### PR TITLE
Correcting the repo name of ModelMapper library.

### DIFF
--- a/libs/java.json
+++ b/libs/java.json
@@ -68,7 +68,7 @@
   {"id":"java.jsonld-java","imports":["com.github.jsonldjava."],"name":"JSONLD-Java","repo":"jsonld-java/jsonld-java","tags":["formats"],"tech":["app-data"],"status":"model-ready"},
   {"id":"java.logan-square","imports":["com.bluelinelabs.logansquare."],"name":"LoganSquare","repo":"bluelinelabs/LoganSquare","tags":["json-parser"],"tech":["app-data"],"status":"model-ready"},
   {"id":"java.map-struct","imports":["org.mapstruct."],"name":"MapStruct","repo":"mapstruct/mapstruct","tags":["mapping"],"tech":["app-data"],"status":"model-ready"},
-  {"id":"java.model-mapper","imports":["org.modelmapper."],"name":"ModelMapper","repo":"jhalterman/modelmapper","tags":["mapping"],"tech":["app-data"],"status":"model-ready"},
+  {"id":"java.model-mapper","imports":["org.modelmapper."],"name":"ModelMapper","repo":"modelmapper/modelmapper","tags":["mapping"],"tech":["app-data"],"status":"model-ready"},
   {"id":"java.moshi","imports":["com.squareup.moshi."],"name":"Moshi","repo":"square/moshi","tags":["json"],"tech":["app-data"],"status":"model-ready"},
   {"id":"java.orika","imports":["ma.glasnost.orika."],"name":"Orika","repo":"orika-mapper/orika","tags":["mapping"],"tech":["app-data"],"status":"model-ready"},
   {"id":"java.protonpack","imports":["com.codepoetics.protonpack."],"name":"protonpack","repo":"poetix/protonpack","tags":["streams"],"tech":["app-data"],"status":"model-ready"},


### PR DESCRIPTION
This branch corrects the name of the git repository of the `ModelMapper` library in the `json` of `Java` libraries. Previously, the project was associated with the author's repository (**jhalterman/modelmapper**), but now has its own repository, as shown in the image below.

![modelmapper](https://user-images.githubusercontent.com/1054867/79031967-32b1e500-7b79-11ea-9629-df4db31ffb15.png)
